### PR TITLE
small fixes

### DIFF
--- a/config_obs.yml
+++ b/config_obs.yml
@@ -37,10 +37,10 @@ extract:  # ------------------------------------- Extraction -------------------
         tas: D
       other_search_criteria:
         source:
-          #- ERA5-Land
-          #- RDRS
-          #- CaSR
-          #- EMDNA
+          - ERA5-Land
+          - RDRS
+          - CaSR
+          - EMDNA
           - PCICBlend
     extract_dataset: &extract
       region: 

--- a/config_obs.yml
+++ b/config_obs.yml
@@ -61,10 +61,6 @@ extract:  # ------------------------------------- Extraction -------------------
         time: -1
         X: 30
         Y: 30
-    chunk:
-        time: -1
-        X: 30
-        Y: 30
 
 # station observations AHCCD
   station-tas:  # ------------------------------------- Station Temperature -------------------------------------

--- a/config_obs.yml
+++ b/config_obs.yml
@@ -37,10 +37,10 @@ extract:  # ------------------------------------- Extraction -------------------
         tas: D
       other_search_criteria:
         source:
-          - ERA5-Land
-          - RDRS
-          - CaSR
-          - EMDNA
+          #- ERA5-Land
+          #- RDRS
+          #- CaSR
+          #- EMDNA
           - PCICBlend
     extract_dataset: &extract
       region: 
@@ -156,7 +156,7 @@ performance:  # ------------------------------------- Performance --------------
       type: ['station-pr', 'station-tas']
     reconstruction: # Parameters used to search exclusively for reconstruction data in the catalog.
       type: ['reconstruction']
-
+  minimum_n_years: 20
   # Expected "statistics" YAML dictionary structure:
   #
   #   statistics:

--- a/config_obs.yml
+++ b/config_obs.yml
@@ -20,7 +20,7 @@ tasks:
 # Task Arguments
 
 extract:  # ------------------------------------- Extraction --------------------------------------------
-# reanalysis
+#reanalysis
   reconstruction:
     dask:
       n_workers: 2
@@ -37,7 +37,7 @@ extract:  # ------------------------------------- Extraction -------------------
         tas: D
       other_search_criteria:
         source:
-          - ERA5-Land
+          #- ERA5-Land
           - RDRS
           - CaSR
           - EMDNA
@@ -58,6 +58,10 @@ extract:  # ------------------------------------- Extraction -------------------
         tasmin: *f32
         pr: *f32
       rechunk:
+        time: -1
+        X: 30
+        Y: 30
+    chunk:
         time: -1
         X: 30
         Y: 30
@@ -104,8 +108,8 @@ extract:  # ------------------------------------- Extraction -------------------
     extract_dataset: *extract
     save:
       rechunk:
-        time: -1
-        station: 50
+       time: -1
+       station: 50
 
 
 
@@ -135,6 +139,7 @@ aggregate:  # ------------------------------------- Climatological Operations --
     processing_level: indicators
   climatological_mean: 
     op: mean
+    min_periods: &min_periods_val 25
   vars_for_interannual_std: &indicators #TODO: make naming clearer
     - tg_mean_annual
     - tg_mean_seasonal
@@ -144,6 +149,7 @@ aggregate:  # ------------------------------------- Climatological Operations --
   #   - pr_std
   climatological_std: # automatically passed to the function
     op: std
+    min_periods: *min_periods_val
 
 performance:  # ------------------------------------- Performance --------------------------------------------------
   # Defines which statistical metrics to compute using functions from xsdba.measures.
@@ -197,7 +203,7 @@ scripting: # send an email when code fails or succeed
 
 set_options:
   data_validation: log
-  check_missing: skip
+  check_missing: wmo
 
 io: 
   save_to_zarr: # passed automatically to all save_to_zarr

--- a/indicators_obs.yml
+++ b/indicators_obs.yml
@@ -19,7 +19,7 @@ indicators:
   tg_mean_annual:
     base: tg_mean
     parameters:
-      freq: YS
+      freq: YS-JAN
   tg_mean_seasonal:
     base: tg_mean
     parameters:
@@ -28,7 +28,7 @@ indicators:
   pr_mean_annual:
     base: prcpavg
     parameters:
-      freq: YS
+      freq: YS-JAN
   pr_mean_seasonal:
     base: prcpavg
     parameters:


### PR DESCRIPTION
I made a few changes to the workflow:
- I think one of the main issue with the random nans was because some stations were closer to a water grid point than a land gridpoint. Hence, the `xs.spatial.subset` introduces nans. Fix: `stack_drop_nan` drops all the nans, so `xs.spatial.subset` can't choose them and choses the next closest gridpoint on land.
- I added a test to make sure there is at least 20 years of valid data in the obs before doing a RMSE.
- I unstack the dates, meaning instead of 1 time axis ( hiver 2000, printemps 2000, été 2000, automne 2000, hiver 2001, ...), I have 1 axis per year and 1 per season (hiver 2000, hiver 2001, .. x printemps 2000, printemps 2001,.. x ... x ....) This allows me to have 1 RMSE per season.
- I changed the path of performance for `{processing_level}/{id}_{variable}_{performance_base}_{processing_level}.zarr` to have clear different path that are not overwriting each other.
- When doing `xs.spatial.subset` we loose information about the stations (like their name). I put it back manually.
- Not in this PR, but I fixed the issue with RMSE handling nans in xsdba. You can do `pip install git+pip install git+https://github.com/Ouranosinc/xsdba.git@nanrmse` in your env to have the correct version.

@ArtemBuyalo Let me know if you have any questions! 